### PR TITLE
add NUMBER data type support to snowflake type lookup

### DIFF
--- a/metrics_layer/cli/seeding.py
+++ b/metrics_layer/cli/seeding.py
@@ -59,6 +59,7 @@ class SeedMetricsLayer:
             "STRING": "string",
             "BINARY": "string",
             "VARBINARY": "string",
+            "NUMBER": "number",
         }
 
         self._redshift_type_lookup = {


### PR DESCRIPTION
**Issue:**
- data type `NUMBER` isn't handled for SnowflakeDB, so columns with that type default to `string` instead of `number` when seeding view.

**Fix**

- Add `"NUMBER": "number"` to `snowflake_type_lookup`