### PR TITLE
Support file paths when loading and dumping the Project

### DIFF
--- a/metrics_layer/core/parse/project_dumper.py
+++ b/metrics_layer/core/parse/project_dumper.py
@@ -13,19 +13,31 @@ class ProjectDumper(ProjectReaderBase):
 
     def dump(self, path: str):
         for model in self.models_to_dump:
-            file_name = model["name"] + "_model.yml"
-            models_folder = os.path.join(path, self._model_folder)
-            if not os.path.exists(models_folder):
-                os.mkdir(models_folder)
-            file_path = os.path.join(models_folder, file_name)
+            if "_file_path" in model:
+                file_path = os.path.join(path, model["_file_path"])
+                directory = os.path.dirname(file_path)
+                if not os.path.exists(directory):
+                    os.makedirs(directory)
+            else:
+                file_name = model["name"] + "_model.yml"
+                models_folder = os.path.join(path, self._model_folder)
+                if not os.path.exists(models_folder):
+                    os.mkdir(models_folder)
+                file_path = os.path.join(models_folder, file_name)
             self.dump_yaml_file(self._sort_model(model), file_path)
 
         for view in self.views_to_dump:
-            file_name = view["name"] + "_view.yml"
-            views_folder = os.path.join(path, self._view_folder)
-            if not os.path.exists(views_folder):
-                os.mkdir(views_folder)
-            file_path = os.path.join(views_folder, file_name)
+            if "_file_path" in view:
+                file_path = os.path.join(path, view["_file_path"])
+                directory = os.path.dirname(file_path)
+                if not os.path.exists(directory):
+                    os.makedirs(directory)
+            else:
+                file_name = view["name"] + "_view.yml"
+                views_folder = os.path.join(path, self._view_folder)
+                if not os.path.exists(views_folder):
+                    os.mkdir(views_folder)
+                file_path = os.path.join(views_folder, file_name)
             self.dump_yaml_file(self._sort_view(view), file_path)
 
     def _sort_view(self, view: dict):

--- a/metrics_layer/core/parse/project_reader_base.py
+++ b/metrics_layer/core/parse/project_reader_base.py
@@ -70,8 +70,9 @@ class ProjectReaderBase:
 
     @staticmethod
     def dump_yaml_file(data: dict, path: str):
+        filtered_data = {k: v for k, v in data.items() if not k.startswith("_")}
         with open(path, "w") as f:
-            ruamel.yaml.dump(data, f, Dumper=ruamel.yaml.RoundTripDumper)
+            ruamel.yaml.dump(filtered_data, f, Dumper=ruamel.yaml.RoundTripDumper)
 
     def load(self) -> None:
         raise NotImplementedError()

--- a/metrics_layer/core/parse/project_reader_metrics_layer.py
+++ b/metrics_layer/core/parse/project_reader_metrics_layer.py
@@ -16,6 +16,7 @@ class MetricsLayerProjectReader(ProjectReaderBase):
 
         for fn in file_names:
             yaml_dict = self.read_yaml_file(fn)
+            yaml_dict["_file_path"] = os.path.relpath(fn, start=self.repo.folder)
 
             # Handle keyerror
             if "type" not in yaml_dict and "zenlytic_project" not in fn:


### PR DESCRIPTION
In this PR:

* I add an attribute `_file_path` to `View`, `Model` and `Dashboard` classes when loading in. The path is relative to `repo.folder` which is the root of the repo folder.
  * The path is not relative to the view/model/dashboard folder specified in `zenlytic_project.yml` for backwards compatibility, since we currently (implicitly) support and read in views living in the model or dashboard folder. See lines 10-13 of `metrics_layer/core/parse/project_reader_metrics_layer.py`. In these cases, having file paths relative to the subfolders will be incorrect.
* Check for `_file_path` attribute when dumping the project and using it if it exists.
* Change `dump_yaml_file` static method to ignore dictionary keys starting with `_`. This allows us to put more hidden keys in the future if necessary.