### PR TITLE
Feature/load using ruamelyaml

### DIFF
--- a/metrics_layer/core/parse/project_reader_base.py
+++ b/metrics_layer/core/parse/project_reader_base.py
@@ -62,8 +62,10 @@ class ProjectReaderBase:
 
     @staticmethod
     def read_yaml_file(path: str):
+        yaml = ruamel.yaml.YAML(typ="rt")
+        yaml.version = (1, 1)
         with open(path, "r") as f:
-            yaml_dict = ruamel.yaml.safe_load(f)
+            yaml_dict = yaml.load(f)
         return yaml_dict
 
     @staticmethod

--- a/metrics_layer/core/parse/project_reader_base.py
+++ b/metrics_layer/core/parse/project_reader_base.py
@@ -1,8 +1,6 @@
 import os
 
 import ruamel.yaml
-import yaml
-
 
 from .github_repo import BaseRepo
 
@@ -64,8 +62,10 @@ class ProjectReaderBase:
 
     @staticmethod
     def read_yaml_file(path: str):
+        import yaml
+
         with open(path, "r") as f:
-            yaml_dict = yaml.safe_load(f)
+            yaml_dict = ruamel.yaml.safe_load(f)
         return yaml_dict
 
     @staticmethod

--- a/metrics_layer/core/parse/project_reader_base.py
+++ b/metrics_layer/core/parse/project_reader_base.py
@@ -62,8 +62,6 @@ class ProjectReaderBase:
 
     @staticmethod
     def read_yaml_file(path: str):
-        import yaml
-
         with open(path, "r") as f:
             yaml_dict = ruamel.yaml.safe_load(f)
         return yaml_dict


### PR DESCRIPTION
This PR changes loading YAML files to use `ruamel.yaml` instead of `PyYAML` since `ruamel.yaml` is generally more robust and catches duplicate key errors.

Note: This PR passes all the tests however there is one behavior change in using `ruamel.yaml` loading instead of `yaml` loading described below.

PyYAML uses 1.1 yaml spec which automatically converts strings `yes`/`no` and `on/off` and `True/False` to boolean `True/False`. Default ruamel.yaml uses version 1.2 yaml specification which treats those strings as strings. Explicitly specifying ruamel.yaml to use version 1.1 mocks this behavior, but v1.1 yaml constructor for ruamel.yaml also converts `y`/`n` and `Y`/`N` strings to True/False while PyYAML treats these as strings.
