### PR TITLE
Fix/join as prefix bug

### DIFF
--- a/metrics_layer/core/model/project.py
+++ b/metrics_layer/core/model/project.py
@@ -142,7 +142,10 @@ class Project:
                     identifier_to_add = {**identifier}
                     identifier_to_add.pop("join_as")
                     if identifier["join_as"] not in join_as_to_create:
-                        view_args = {"identifiers": [identifier_to_add]}
+                        view_args = {
+                            "identifiers": [identifier_to_add],
+                            "fields": deepcopy(v.get("fields", [])),
+                        }
                         if "join_as_label" in identifier:
                             view_args["label"] = identifier["join_as_label"]
 
@@ -155,7 +158,9 @@ class Project:
 
                         include_metrics = identifier.get("include_metrics", False)
                         if not include_metrics:
-                            v["fields"] = [f for f in v["fields"] if f.get("field_type") != "measure"]
+                            view_args["fields"] = [
+                                f for f in view_args["fields"] if f.get("field_type") != "measure"
+                            ]
 
                         join_as_to_create[identifier["join_as"]] = {**v, **view_args}
 

--- a/metrics_layer/core/model/view.py
+++ b/metrics_layer/core/model/view.py
@@ -157,7 +157,8 @@ class View(MetricsLayerBase):
     def _all_fields(self, expand_dimension_groups: bool):
         fields = []
         for f in self._definition.get("fields", []):
-            f["label_prefix"] = self.field_prefix
+            if self.field_prefix:
+                f["label_prefix"] = self.field_prefix
             field = Field(f, view=self)
             if self.project.can_access_field(field):
                 if expand_dimension_groups and field.field_type == "dimension_group":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metrics_layer"
-version = "0.11.29"
+version = "0.11.30"
 description = "The open source metrics layer."
 authors = ["Paul Blankley <paul@zenlytic.com>"]
 keywords = ["Metrics Layer", "Business Intelligence", "Analytics"]

--- a/tests/config/metrics_layer_config/views/accounts.yml
+++ b/tests/config/metrics_layer_config/views/accounts.yml
@@ -11,18 +11,18 @@ identifiers:
     type: primary
     sql: ${account_id}
 
+  - name: child_account_id
+    type: primary
+    sql: ${account_id}
+    join_as: child_account
+    join_as_label: 'Sub Account'
+
   - name: parent_account_id
     type: primary
     sql: ${account_id}
     join_as: parent_account
     join_as_field_prefix: 'Parent'
     include_metrics: yes
-
-  - name: child_account_id
-    type: primary
-    sql: ${account_id}
-    join_as: child_account
-    join_as_label: 'Sub Account'
 
 fields:
   - name: account_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -938,9 +938,9 @@ def test_cli_validate_required_access_filters(connection, fresh_project, mocker)
         " other_db_traffic does not have any access filters, but an access filter with user attribute"
         " products is required.\n\n\nView created_workspace does not have any access filters, but an"
         " access filter with user attribute products is required.\n\n\nView mrr does not have any access"
-        " filters, but an access filter with user attribute products is required.\n\n\nView parent_account"
+        " filters, but an access filter with user attribute products is required.\n\n\nView child_account"
         " does not have any access filters, but an access filter with user attribute products is"
-        " required.\n\n\nView child_account does not have any access filters, but an access filter with"
+        " required.\n\n\nView parent_account does not have any access filters, but an access filter with"
         " user attribute products is required.\n\n"
     )
 
@@ -1020,7 +1020,7 @@ def test_cli_list(connection, mocker, object_type: str, extra_args: list):
         "connections": "Found 3 connections:\n\ntesting_snowflake\ntesting_bigquery\ntesting_databricks\n",
         "views": (  # noqa
             "Found 20"
-            " views:\n\norder_lines\norders\ncustomers\ndiscounts\ndiscount_detail\ncountry_detail\nsessions\nevents\nlogin_events\ntraffic\nclicked_on_page\nsubmitted_form\naccounts\naa_acquired_accounts\nz_customer_accounts\nother_db_traffic\ncreated_workspace\nmrr\nparent_account\nchild_account\n"  # noqa
+            " views:\n\norder_lines\norders\ncustomers\ndiscounts\ndiscount_detail\ncountry_detail\nsessions\nevents\nlogin_events\ntraffic\nclicked_on_page\nsubmitted_form\naccounts\naa_acquired_accounts\nz_customer_accounts\nother_db_traffic\ncreated_workspace\nmrr\nchild_account\nparent_account\n"  # noqa
         ),
         "fields": "Found 2 fields:\n\ndiscount_promo_name\ndiscount_usd\n",
         "dimensions": "Found 3 dimensions:\n\ncountry\norder\ndiscount_code\n",

--- a/tests/test_join_query.py
+++ b/tests/test_join_query.py
@@ -966,3 +966,26 @@ def test_join_as_label(connection):
     view = connection.project.get_view("parent_account")
     assert view.name == "parent_account"
     assert view.fields()[0].label == "Parent Account Id"
+
+
+@pytest.mark.query
+def test_join_as_label_field_level(connection):
+    child_account_id = connection.project.get_field("child_account.account_id")
+    assert child_account_id.name == "account_id"
+    assert child_account_id.label_prefix == "Sub Account"
+    assert child_account_id.label == "Sub Account Account Id"
+
+    parent_account_id = connection.project.get_field("parent_account.account_id")
+    assert parent_account_id.name == "account_id"
+    assert parent_account_id.label_prefix == "Parent"
+    assert parent_account_id.label == "Parent Account Id"
+
+    child_account_name = connection.project.get_field("child_account.account_name")
+    assert child_account_name.name == "account_name"
+    assert child_account_name.label_prefix == "Sub Account"
+    assert child_account_name.label == "Sub Account Account Name"
+
+    parent_account_name = connection.project.get_field("parent_account.account_name")
+    assert parent_account_name.name == "account_name"
+    assert parent_account_name.label_prefix == "Parent"
+    assert parent_account_name.label == "Parent Account Name"

--- a/tests/test_listing_functions.py
+++ b/tests/test_listing_functions.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.project
 def test_list_metrics(connection):
     metrics = connection.list_metrics()
-    assert len(metrics) == 54
+    assert len(metrics) == 55
 
     metrics = connection.list_metrics(view_name="order_lines", names_only=True)
     assert len(metrics) == 11

--- a/tests/test_merged_results.py
+++ b/tests/test_merged_results.py
@@ -145,6 +145,7 @@ def test_merged_result_join_graph(connection):
     sub_q_0_10 = _blow_out_by_time_frame("merged_result_subquery_0_subquery_10", core_tf)
     sub_q_0_11 = _blow_out_by_time_frame("merged_result_subquery_0_subquery_11", core_tf)
     sub_q_0_12 = _blow_out_by_time_frame("merged_result_subquery_0_subquery_12", core_tf)
+    sub_q_0_14 = _blow_out_by_time_frame("merged_result_subquery_0_subquery_14", core_tf)
     sub_q_0_15 = _blow_out_by_time_frame("merged_result_subquery_0_subquery_15", core_tf)
     sub_q_0_1 = _blow_out_by_time_frame("merged_result_subquery_0_subquery_1", core_tf)
     revenue_set = [
@@ -158,6 +159,7 @@ def test_merged_result_join_graph(connection):
         *sub_q_0_10,
         *sub_q_0_11,
         *sub_q_0_12,
+        *sub_q_0_14,
         *sub_q_0_15,
         *sub_q_0_1,
     ]
@@ -174,6 +176,7 @@ def test_merged_result_join_graph(connection):
         "merged_result_subquery_0_subquery_10_date",
         "merged_result_subquery_0_subquery_11_date",
         "merged_result_subquery_0_subquery_12_date",
+        "merged_result_subquery_0_subquery_14_date",
         "merged_result_subquery_0_subquery_15_date",
         "merged_result_subquery_0_subquery_1_date",
         "merged_result_subquery_0_subquery_4_date",
@@ -192,6 +195,7 @@ def test_merged_result_join_graph(connection):
         "merged_result_subquery_0_subquery_10_date",
         "merged_result_subquery_0_subquery_11_date",
         "merged_result_subquery_0_subquery_12_date",
+        "merged_result_subquery_0_subquery_14_date",
         "merged_result_subquery_0_subquery_15_date",
         "merged_result_subquery_0_subquery_1_date",
         "merged_result_subquery_0_subquery_4_date",
@@ -259,6 +263,7 @@ def test_merged_result_join_graph(connection):
         *_blow_out_by_time_frame("merged_result_subquery_3_subquery_4", core_tf),
         *_blow_out_by_time_frame("merged_result_subquery_4_subquery_7", core_tf),
         *_blow_out_by_time_frame("merged_result_subquery_4_subquery_5", core_tf),
+        *_blow_out_by_time_frame("merged_result_subquery_14_subquery_4", core_tf),
         *_blow_out_by_time_frame("merged_result_subquery_15_subquery_4", core_tf),
         *_blow_out_by_time_frame("merged_result_subquery_4_subquery_8", core_tf),
         *_blow_out_by_time_frame("merged_result_subquery_4_subquery_9", core_tf),


### PR DESCRIPTION
This fixes an issue where the last prefix value would be incorrectly copied for all other `join_as` fields due to a python reference that was not properly copied