### PR TITLE
Fix/ignore repos

### DIFF
--- a/metrics_layer/core/parse/.gitignore
+++ b/metrics_layer/core/parse/.gitignore
@@ -1,0 +1,2 @@
+# Ignore downloaded data model repositories
+*/

--- a/metrics_layer/core/parse/.gitignore
+++ b/metrics_layer/core/parse/.gitignore
@@ -1,0 +1,6 @@
+# This file ignores itself to prevent Git from tracking dynamic updates! See note below.
+# To stage changes anyway, add the `-f` flag to `git add`.
+.gitignore
+
+# Paths to downloaded data model repositories are dynamically added to the end of this
+# file. This prevents Git from tracking them.

--- a/metrics_layer/core/parse/.gitignore
+++ b/metrics_layer/core/parse/.gitignore
@@ -1,6 +1,0 @@
-# This file ignores itself to prevent Git from tracking dynamic updates! See note below.
-# To stage changes anyway, add the `-f` flag to `git add`.
-.gitignore
-
-# Paths to downloaded data model repositories are dynamically added to the end of this
-# file. This prevents Git from tracking them.

--- a/metrics_layer/core/parse/github_repo.py
+++ b/metrics_layer/core/parse/github_repo.py
@@ -1,14 +1,37 @@
 import os
+import pathlib
 import shutil
 from glob import glob
-import pathlib
-import yaml
+from tempfile import NamedTemporaryFile
 
 import git
+import yaml
 
 from metrics_layer.core import utils
 
 BASE_PATH = os.path.dirname(__file__)
+
+
+class _GitIgnore:
+    _path = pathlib.Path(".gitignore")
+
+    @classmethod
+    def add_repo(cls, folder: str):
+        with cls._path.open("a") as file:
+            file.write(f"{folder}\n")
+
+    @classmethod
+    def remove_repo(cls, folder: str):
+        with cls._path.open() as file:
+            lines = file.readlines()
+
+        with NamedTemporaryFile("w", delete=False) as tempfile:
+            # Write to a temporary file instead of directly to the original file. This
+            # effectively makes the multiple writes atomic; if any of the writes fail,
+            # the original file is not modified.
+            tempfile.writelines(line for line in lines if line != f"{folder}\n")
+
+        cls._path = pathlib.Path(tempfile.name).replace(cls._path)
 
 
 class BaseRepo:
@@ -92,6 +115,7 @@ class GithubRepo(BaseRepo):
 
     def fetch(self, private_key: str = None):
         self.git_repo, branch_options, self._file_path = self.fetch_github_repo(private_key)
+        _GitIgnore.add_repo(self.folder)
         self.dbt_path = self.get_dbt_path()
         self.branch_options = branch_options
 
@@ -101,6 +125,7 @@ class GithubRepo(BaseRepo):
 
         if os.path.exists(folder) and os.path.isdir(folder):
             shutil.rmtree(folder)
+            _GitIgnore.remove_repo(folder)
 
     def create_branch(self, branch_name: str, private_key: str = None):
         self._ssh_wrapped(self.__create_branch, branch_name=branch_name, private_key=private_key)
@@ -186,6 +211,7 @@ class GithubRepo(BaseRepo):
     def _fetch_github_repo_https(repo_url: str, repo_destination: str, branch: str):
         if os.path.exists(repo_destination) and os.path.isdir(repo_destination):
             shutil.rmtree(repo_destination)
+            _GitIgnore.remove_repo(f"{repo_destination}/")
         repo = git.Repo.clone_from(repo_url, to_path=repo_destination, branch=branch)
         branch_options = GithubRepo._fetch_branch_options(repo, branch)
         return repo, branch_options


### PR DESCRIPTION
The metrics layer clones each data model into a new directory in `metrics_layer/core/parse/`, e.g., `metrics_layer/core/parse/8ae80fdf-63ff-4e4c-9e80-5d7006f6341e/`. These new directories are not tracked by Git, so when the metrics layer is used as a submodule, Git pollutes `git status` with the untracked content ready to stage: 
<img width="800" alt="result of git status with untracked content in submodule" src="https://github.com/user-attachments/assets/aa55f40a-3157-479b-bd9d-141b98a87a1d">

To resolve this annoyance, this PR adds all folders in `metrics_layer/core/parse/` to `.gitignore`. This may cause problems in the future if packages are added (each their own folder that will get ignored). The easiest workaround is to `git add -f` those folders to forcibly track them. Another workaround is to dynamically add each data model directory to `.gitignore` when it is fetched. This complicates things a lot, but a partial implementation can be found in the commit history of this branch.