### PR TITLE
Fix/add datetime tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest --cov=metrics_layer/ --cov-report=xml
+          pytest -m extra_dt --cov=metrics_layer/ --cov-report=xml
 
       - name: Report on code coverage
         uses: codecov/codecov-action@v4

--- a/metrics_layer/core/model/filter.py
+++ b/metrics_layer/core/model/filter.py
@@ -306,12 +306,7 @@ class Filter(MetricsLayerBase):
             # We need to figure out how many days are between now and the start of the period
             start_of_period = Filter._start_date(lag=0, date_part=date_part, tz=tz, return_date=True)
             time_change = Filter._today(tz=tz) - start_of_period
-            if date_part == "year" and time_change.days == 0:
-                lag = -1
-            elif time_change.days > 0:
-                lag = time_change.days - 1
-            else:
-                lag = 0
+            lag = time_change.days - 1 if time_change.days > 0 else 0
             end_date = Filter._add_to_end_date(start_date, lag=lag, date_part="day")
             result.append((end_expression, Filter._date_to_string(end_date)))
 

--- a/metrics_layer/core/model/filter.py
+++ b/metrics_layer/core/model/filter.py
@@ -306,7 +306,12 @@ class Filter(MetricsLayerBase):
             # We need to figure out how many days are between now and the start of the period
             start_of_period = Filter._start_date(lag=0, date_part=date_part, tz=tz, return_date=True)
             time_change = Filter._today(tz=tz) - start_of_period
-            lag = time_change.days - 1 if time_change.days > 0 else 0
+            if date_part == "year" and time_change.days == 0:
+                lag = -1
+            elif time_change.days > 0:
+                lag = time_change.days - 1
+            else:
+                lag = 0
             end_date = Filter._add_to_end_date(start_date, lag=lag, date_part="day")
             result.append((end_expression, Filter._date_to_string(end_date)))
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1493,6 +1493,7 @@ files = [
 "backports.zoneinfo" = {version = ">=0.2.1", markers = "python_version < \"3.9\""}
 importlib-resources = {version = ">=5.9.0", markers = "python_version < \"3.9\""}
 python-dateutil = ">=2.6"
+time-machine = {version = ">=2.6.0", optional = true, markers = "implementation_name != \"pypy\" and extra == \"test\""}
 tzdata = ">=2020.1"
 
 [package.extras]
@@ -2288,6 +2289,54 @@ description = "Database Abstraction Library"
 optional = true
 python-versions = ">=3.7"
 files = [
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0c9045ecc2e4db59bfc97b20516dfdf8e41d910ac6fb667ebd3a79ea54084619"},
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1467940318e4a860afd546ef61fefb98a14d935cd6817ed07a228c7f7c62f389"},
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5954463675cb15db8d4b521f3566a017c8789222b8316b1e6934c811018ee08b"},
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:167e7497035c303ae50651b351c28dc22a40bb98fbdb8468cdc971821b1ae533"},
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b27dfb676ac02529fb6e343b3a482303f16e6bc3a4d868b73935b8792edb52d0"},
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bf2360a5e0f7bd75fa80431bf8ebcfb920c9f885e7956c7efde89031695cafb8"},
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-win32.whl", hash = "sha256:306fe44e754a91cd9d600a6b070c1f2fadbb4a1a257b8781ccf33c7067fd3e4d"},
+    {file = "SQLAlchemy-2.0.32-cp310-cp310-win_amd64.whl", hash = "sha256:99db65e6f3ab42e06c318f15c98f59a436f1c78179e6a6f40f529c8cc7100b22"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:21b053be28a8a414f2ddd401f1be8361e41032d2ef5884b2f31d31cb723e559f"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b178e875a7a25b5938b53b006598ee7645172fccafe1c291a706e93f48499ff5"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:723a40ee2cc7ea653645bd4cf024326dea2076673fc9d3d33f20f6c81db83e1d"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:295ff8689544f7ee7e819529633d058bd458c1fd7f7e3eebd0f9268ebc56c2a0"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:49496b68cd190a147118af585173ee624114dfb2e0297558c460ad7495f9dfe2"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:acd9b73c5c15f0ec5ce18128b1fe9157ddd0044abc373e6ecd5ba376a7e5d961"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-win32.whl", hash = "sha256:9365a3da32dabd3e69e06b972b1ffb0c89668994c7e8e75ce21d3e5e69ddef28"},
+    {file = "SQLAlchemy-2.0.32-cp311-cp311-win_amd64.whl", hash = "sha256:8bd63d051f4f313b102a2af1cbc8b80f061bf78f3d5bd0843ff70b5859e27924"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6bab3db192a0c35e3c9d1560eb8332463e29e5507dbd822e29a0a3c48c0a8d92"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:19d98f4f58b13900d8dec4ed09dd09ef292208ee44cc9c2fe01c1f0a2fe440e9"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cd33c61513cb1b7371fd40cf221256456d26a56284e7d19d1f0b9f1eb7dd7e8"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d6ba0497c1d066dd004e0f02a92426ca2df20fac08728d03f67f6960271feec"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2b6be53e4fde0065524f1a0a7929b10e9280987b320716c1509478b712a7688c"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:916a798f62f410c0b80b63683c8061f5ebe237b0f4ad778739304253353bc1cb"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-win32.whl", hash = "sha256:31983018b74908ebc6c996a16ad3690301a23befb643093fcfe85efd292e384d"},
+    {file = "SQLAlchemy-2.0.32-cp312-cp312-win_amd64.whl", hash = "sha256:4363ed245a6231f2e2957cccdda3c776265a75851f4753c60f3004b90e69bfeb"},
+    {file = "SQLAlchemy-2.0.32-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b8afd5b26570bf41c35c0121801479958b4446751a3971fb9a480c1afd85558e"},
+    {file = "SQLAlchemy-2.0.32-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c750987fc876813f27b60d619b987b057eb4896b81117f73bb8d9918c14f1cad"},
+    {file = "SQLAlchemy-2.0.32-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ada0102afff4890f651ed91120c1120065663506b760da4e7823913ebd3258be"},
+    {file = "SQLAlchemy-2.0.32-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:78c03d0f8a5ab4f3034c0e8482cfcc415a3ec6193491cfa1c643ed707d476f16"},
+    {file = "SQLAlchemy-2.0.32-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:3bd1cae7519283ff525e64645ebd7a3e0283f3c038f461ecc1c7b040a0c932a1"},
+    {file = "SQLAlchemy-2.0.32-cp37-cp37m-win32.whl", hash = "sha256:01438ebcdc566d58c93af0171c74ec28efe6a29184b773e378a385e6215389da"},
+    {file = "SQLAlchemy-2.0.32-cp37-cp37m-win_amd64.whl", hash = "sha256:4979dc80fbbc9d2ef569e71e0896990bc94df2b9fdbd878290bd129b65ab579c"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c742be912f57586ac43af38b3848f7688863a403dfb220193a882ea60e1ec3a"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:62e23d0ac103bcf1c5555b6c88c114089587bc64d048fef5bbdb58dfd26f96da"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:251f0d1108aab8ea7b9aadbd07fb47fb8e3a5838dde34aa95a3349876b5a1f1d"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ef18a84e5116340e38eca3e7f9eeaaef62738891422e7c2a0b80feab165905f"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3eb6a97a1d39976f360b10ff208c73afb6a4de86dd2a6212ddf65c4a6a2347d5"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0c1c9b673d21477cec17ab10bc4decb1322843ba35b481585facd88203754fc5"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-win32.whl", hash = "sha256:c41a2b9ca80ee555decc605bd3c4520cc6fef9abde8fd66b1cf65126a6922d65"},
+    {file = "SQLAlchemy-2.0.32-cp38-cp38-win_amd64.whl", hash = "sha256:8a37e4d265033c897892279e8adf505c8b6b4075f2b40d77afb31f7185cd6ecd"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:52fec964fba2ef46476312a03ec8c425956b05c20220a1a03703537824b5e8e1"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:328429aecaba2aee3d71e11f2477c14eec5990fb6d0e884107935f7fb6001632"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85a01b5599e790e76ac3fe3aa2f26e1feba56270023d6afd5550ed63c68552b3"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaf04784797dcdf4c0aa952c8d234fa01974c4729db55c45732520ce12dd95b4"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4488120becf9b71b3ac718f4138269a6be99a42fe023ec457896ba4f80749525"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:14e09e083a5796d513918a66f3d6aedbc131e39e80875afe81d98a03312889e6"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-win32.whl", hash = "sha256:0d322cc9c9b2154ba7e82f7bf25ecc7c36fbe2d82e2933b3642fc095a52cfc78"},
+    {file = "SQLAlchemy-2.0.32-cp39-cp39-win_amd64.whl", hash = "sha256:7dd8583df2f98dea28b5cd53a1beac963f4f9d087888d75f22fcc93a07cf8d84"},
+    {file = "SQLAlchemy-2.0.32-py3-none-any.whl", hash = "sha256:e567a8793a692451f706b363ccf3c45e056b67d90ead58c3bc9471af5d212202"},
     {file = "SQLAlchemy-2.0.32.tar.gz", hash = "sha256:c1b88cc8b02b6a5f0efb0345a03672d4c897dc7d92585176f88c67346f565ea8"},
 ]
 
@@ -2334,6 +2383,85 @@ files = [
 [package.extras]
 dev = ["build", "hatch"]
 doc = ["sphinx"]
+
+[[package]]
+name = "time-machine"
+version = "2.15.0"
+description = "Travel through time in your tests."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "time_machine-2.15.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:892d016789b59950989b2db188dcd46cf16d34e8daf2343e33b679b0c5fd1001"},
+    {file = "time_machine-2.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4428bdae507996aa3fdeb4727bca09e26306fa64a502e7335207252684516cbf"},
+    {file = "time_machine-2.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0302568338c8bd333ed0698231dbb781b70ead1a5579b4ac734b9bf88313229f"},
+    {file = "time_machine-2.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18fc4740073e67071472c48355775ec6d1b93af5c675524b7de2474e0dcd8741"},
+    {file = "time_machine-2.15.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:768d33b484a35da93731cc99bdc926b539240a78673216cdc6306833d9072350"},
+    {file = "time_machine-2.15.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:73a8c8160d2a170dadcad5b82fb5ee53236a19cec0996651cf4d21da0a2574d5"},
+    {file = "time_machine-2.15.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:09fd839a321a92aa8183206c383b9725eaf4e0a28a70e4cb87db292b352eeefb"},
+    {file = "time_machine-2.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:838a6d117739f1ae6ecc45ec630fa694f41a85c0d07b1f3b1db2a6cc52c1808b"},
+    {file = "time_machine-2.15.0-cp310-cp310-win32.whl", hash = "sha256:d24d2ec74923b49bce7618e3e7762baa6be74e624d9829d5632321de102bf386"},
+    {file = "time_machine-2.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:95c8e7036cf442480d0bf6f5fde371e1eb6dbbf5391d7bdb8db73bd8a732b538"},
+    {file = "time_machine-2.15.0-cp310-cp310-win_arm64.whl", hash = "sha256:660810cd27a8a94cb5e845e8f28a95e70b01ff0c45466d394c4a0cba5a0ae279"},
+    {file = "time_machine-2.15.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:674097dd54a0bbd555e7927092c74428c4c07268ad52bca38cfccc3214707e50"},
+    {file = "time_machine-2.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4e83fd6112808d1d14d1a57397c6fa3bd71bb2f3b8800036e12366e3680819b9"},
+    {file = "time_machine-2.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b095a1de40ca1afaeae8df3f45e26b645094a1912e6e6871e725fcf06ecdb74a"},
+    {file = "time_machine-2.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4601fe7a6b74c6fd9207e614d9db2a20dd4befd4d314677a0feac13a67189707"},
+    {file = "time_machine-2.15.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:245ef73f9927b7d4909d554a6a0284dbc5dee9730adea599e430b37c9e9fa203"},
+    {file = "time_machine-2.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:704abc7f3403584cca9c01c5809812e0bd70632ea4251389fae4f45e11aad94f"},
+    {file = "time_machine-2.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6425001e50a0c82108caed438233066cea04d42a8fc9c49bfcf081a5b96e5b4e"},
+    {file = "time_machine-2.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d4073b754f90b19f28d036ec5143d3fca3a75e4d4241d78790a6178b00bb373"},
+    {file = "time_machine-2.15.0-cp311-cp311-win32.whl", hash = "sha256:8817b0f7d7830215261b18db83c9c3ef1da6bb64da5c292d7c70b9a46e5a6745"},
+    {file = "time_machine-2.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:ddad27a62df2ea47b7b483009fbfcf167a71d702cbd8e2eefd9ddc1c93146658"},
+    {file = "time_machine-2.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:6f021aa2dbd8fbfe54d3fa2258518129108b7496922b3bcff2cf5991078eec67"},
+    {file = "time_machine-2.15.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:a22f47c34ee1fcf7d93a8c5c93135499aac879d9d5d8f820bd28571a30fdabcd"},
+    {file = "time_machine-2.15.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b684f8ecdeacd6baabc17b15ac1b054ca62029193e6c5367ef00b3516671de80"},
+    {file = "time_machine-2.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f7add997684bc6141e1c80f6ba0c38ffe316ba277a4074e61b1b7b4f5a172bf"},
+    {file = "time_machine-2.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31af56399bf7c9ef76a3f7b6d9471dffa8f06ee373c194a374b69523f9061de9"},
+    {file = "time_machine-2.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5b94cba3edfc54bcb3ab5be616a2f50fa48be438e5af970824efdf882d1bc31"},
+    {file = "time_machine-2.15.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3862dda89bdb05f9d521b08fdcb24b19a7dd9f559ae324f4301ba7a07b6eea64"},
+    {file = "time_machine-2.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e1790481a6b9ce38888f22ce30710244067898c3ac4805a0e061e381f3db3506"},
+    {file = "time_machine-2.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a731c03bc00552ee6cc685a59616d36003124e7e04c6ddf65c2c47f1c3d85480"},
+    {file = "time_machine-2.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e6776840aea3ff5ab6924b50117957da62db51b109b3b491c0d5817a804b1a8e"},
+    {file = "time_machine-2.15.0-cp312-cp312-win32.whl", hash = "sha256:9479530e3fce65f6149058071fa4df8150025f15b43b103445f619842981a87c"},
+    {file = "time_machine-2.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:b5f3ab4185c1f72010846ca9fccb08349e23a2b52982a18d9870e848ce9f1c86"},
+    {file = "time_machine-2.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:c0473dfa8f17c6a9a250b2bd6a5b62af3aa7d22518f701649115f1085d5e35ab"},
+    {file = "time_machine-2.15.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f50f10058b884d45cd8a50423bf561b1f9f9df7058abeb8b318700c8bcf4bb54"},
+    {file = "time_machine-2.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:df6f618b98f0848fd8d07039541e10f23db679d8283f8719e870a98e1ef8e639"},
+    {file = "time_machine-2.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52468a0784544eba708c0ae6bc5e8c5dcfd685495a60f7f74028662c984bd9cd"},
+    {file = "time_machine-2.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c08800c28160f4d32ca510128b4e201a43c813e7a2dd53178fa79ebe050eba13"},
+    {file = "time_machine-2.15.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65d395211736d9844537a530287a7c64b9fda1d353e899a0e1723986a0859154"},
+    {file = "time_machine-2.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3b177d334a35bf2ce103bfe4e0e416e4ee824dd33386ea73fa7491c17cc61897"},
+    {file = "time_machine-2.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9a6a9342fae113b12aab42c790880c549d9ba695b8deff27ee08096eedd67569"},
+    {file = "time_machine-2.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bcbb25029ee8756f10c6473cea5ef21707a1d9a8752cdf29fad3a5f34aa4a313"},
+    {file = "time_machine-2.15.0-cp313-cp313-win32.whl", hash = "sha256:29b988b1f09f2a083b12b6b054787b799ae91ee15bb0e9de3e48f880e4d68674"},
+    {file = "time_machine-2.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:d828721dcbcb94b904a6b25df67c2513ecd24cd9e36694f38b9f0fa71c7c6103"},
+    {file = "time_machine-2.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:008bd668d933b1a029c81805bcdc0132390c2545b103cf8e6709e3adbc37989d"},
+    {file = "time_machine-2.15.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e99689f6c6b9ca6e2fc7a75d140e38c5a7985dab61fe1f4e506268f7e9844e05"},
+    {file = "time_machine-2.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:671e88a6209a1cf415dc0f8c67d2b2d3b55b436cc63801a518f9800ebd752959"},
+    {file = "time_machine-2.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b2d28daf4cabc698aafb12135525d87dc1f2f893cbd29a8a6fe0d8d36d1342c"},
+    {file = "time_machine-2.15.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4cd9f057457d12604be18b623bcd5ae7d0b917ad66cb510ee1135d5f123666e2"},
+    {file = "time_machine-2.15.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97dc6793e512a62ba9eab250134a2e67372c16ae9948e73d27c2ef355356e2e1"},
+    {file = "time_machine-2.15.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:0630a32e9ebcf2fac3704365b31e271fef6eabd6fedfa404cd8dbd244f7fc84d"},
+    {file = "time_machine-2.15.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:617c9a92d8d8f60d5ef39e76596620503752a09f834a218e5b83be352fdd6c91"},
+    {file = "time_machine-2.15.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3f7eadd820e792de33a9ec91f8178a2b9088e4e8b9a166953419ddc4ec5f7cfe"},
+    {file = "time_machine-2.15.0-cp38-cp38-win32.whl", hash = "sha256:b7b647684eb2e1fd1e5e6b101249d5fe9d6117c117b5e336ad8dd75af48d2d1f"},
+    {file = "time_machine-2.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:b48abd7745caec1a78a16a048966cde14ff6ccb04d471a7201532648d3f77d14"},
+    {file = "time_machine-2.15.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8c2b1c91b437133c672e374857eccb1dd2c2d9f8477ae3b35138382d5ef19846"},
+    {file = "time_machine-2.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:79bf1ef6850182e09d86e61fa31717da56014a3b2234afb025fca1f2a43ac07b"},
+    {file = "time_machine-2.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:658ea8477fa020f08435fb7277635eb0b50cd5206b9d4cbe10e9a5466b01f855"},
+    {file = "time_machine-2.15.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c947135750d20f35acac290c34f1acf5771fc166a3fbc0e3816a97c756aaa5f5"},
+    {file = "time_machine-2.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dee3a0dd1866988c49a5d00564404db9bcdf49ca92f9c4e8b6c99609d64e698"},
+    {file = "time_machine-2.15.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c596920d6017702a36e3a43fd8110a84e87d6229f30b84bd5640cbae9b5145da"},
+    {file = "time_machine-2.15.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:014589d0edd4aa14f8d63985745565e8cbbe48461d6c004a96000b47f6b44e78"},
+    {file = "time_machine-2.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5ff655716cd13a242eef8cf5d368074e8b396ff86508a5933e7cff4f2b3eb3c2"},
+    {file = "time_machine-2.15.0-cp39-cp39-win32.whl", hash = "sha256:1168eebd7af7e6e3e2fd378c16ca917b97dd81c89a1f1f9e1daa985c81699d90"},
+    {file = "time_machine-2.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:c344eb09fcfbf71e5b5847d4f188fec98e1c3a976125ef571eac5f1c39e7a5e5"},
+    {file = "time_machine-2.15.0-cp39-cp39-win_arm64.whl", hash = "sha256:899f1a856b3bebb82b6cbc3c0014834b583b83f246b28e462a031ec1b766130b"},
+    {file = "time_machine-2.15.0.tar.gz", hash = "sha256:ebd2e63baa117ded04b978813fcd1279d3fc6be2149c9cac75c716b6f1db774c"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
 
 [[package]]
 name = "toml"
@@ -2451,4 +2579,4 @@ snowflake = ["pyarrow", "snowflake-connector-python"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1, <3.13"
-content-hash = "e04729b9bcb87221c0b46456c02c33117065fdc54cd9e8d1ab90dc6408682400"
+content-hash = "7812c5b54e7090b4ee403c39f8f389ad26079f364c952022de034d7d765fc1bb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ isort = "^5.9.3"
 pytest-cov = "^2.12.1"
 pytest-mock = "^3.6.1"
 pytest-xdist = "^3.5.0"
+pendulum = {version = "^3.0.0", extras = ["test"]}
 
 
 [tool.poetry.extras]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = -m "not extra_dt"
 testpaths = tests
 markers =
     cli
@@ -8,3 +9,5 @@ markers =
     dbt
     seeding
     validation
+    primary_dt: mark this as a primary datetime test (included by default). It depends on a certain datetime to run. The primary tests test the bare minimum number of datetimes, usually just the current datetime.
+    extra_dt: mark this as an extra datetime test (excluded by default). It depends on a certain datetime to run. The extra tests are of secondary importance, adding runtime to the test suite but improving robustness. To include these, add `-m extra_dt`.

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -4,6 +4,15 @@ import pytest
 from metrics_layer.core import MetricsLayerConnection
 from metrics_layer.core.exceptions import QueryError
 
+_NOW = pendulum.now("UTC")
+_THIS_YEAR = _NOW.end_of("year").diff(_NOW.start_of("year"))
+
+
+def _generate_dt_params():
+    yield pytest.param(_NOW, marks=pytest.mark.primary_dt)
+    for dt in _THIS_YEAR.range("days"):
+        yield pytest.param(dt, marks=pytest.mark.extra_dt)
+
 
 def test_dashboard_located(connection):
     dash = connection.get_dashboard("sales_dashboard")
@@ -59,72 +68,76 @@ def test_dashboard_to_dict(connection):
 
 
 @pytest.mark.query
-def test_dashboard_filter_week_start(fresh_project):
-    date_format = "%Y-%m-%dT%H:%M:%S"
-    fresh_project._models[0]["week_start_day"] = "sunday"
-    connection = MetricsLayerConnection(project=fresh_project, connections=[])
-    dash = connection.get_dashboard("sales_dashboard")
+@pytest.mark.parametrize("dt", _generate_dt_params())
+def test_dashboard_filter_week_start(fresh_project, dt):
+    with pendulum.travel_to(dt):
+        date_format = "%Y-%m-%dT%H:%M:%S"
+        fresh_project._models[0]["week_start_day"] = "sunday"
+        connection = MetricsLayerConnection(project=fresh_project, connections=[])
+        dash = connection.get_dashboard("sales_dashboard")
 
-    raw_filter_dict = {"field": "orders.order_year", "value": "1 week"}
-    dash.filters = [raw_filter_dict]
-    dashboard_parsed_filters = dash.parsed_filters()
+        raw_filter_dict = {"field": "orders.order_year", "value": "1 week"}
+        dash.filters = [raw_filter_dict]
+        dashboard_parsed_filters = dash.parsed_filters()
 
-    last_element = dash.elements()[-1]
-    last_element.filters = [raw_filter_dict]
-    element_parsed_filters = last_element.parsed_filters()
+        last_element = dash.elements()[-1]
+        last_element.filters = [raw_filter_dict]
+        element_parsed_filters = last_element.parsed_filters()
 
-    pendulum.week_starts_at(pendulum.SUNDAY)
-    pendulum.week_ends_at(pendulum.SATURDAY)
-    start = pendulum.now("UTC").start_of("week").subtract(days=0).strftime(date_format)
-    end = pendulum.now("UTC").end_of("week").subtract(days=0).strftime(date_format)
-    pendulum.week_starts_at(pendulum.MONDAY)
-    pendulum.week_ends_at(pendulum.SUNDAY)
+        pendulum.week_starts_at(pendulum.SUNDAY)
+        pendulum.week_ends_at(pendulum.SATURDAY)
+        start = pendulum.now("UTC").start_of("week").subtract(days=0).strftime(date_format)
+        end = pendulum.now("UTC").end_of("week").subtract(days=0).strftime(date_format)
+        pendulum.week_starts_at(pendulum.MONDAY)
+        pendulum.week_ends_at(pendulum.SUNDAY)
 
-    correct = [
-        {"field": "orders.order_year", "value": start, "expression": "greater_or_equal_than"},
-        {"field": "orders.order_year", "value": end, "expression": "less_or_equal_than"},
-    ]
-    for parsed_filters in [dashboard_parsed_filters, element_parsed_filters]:
-        assert parsed_filters[0]["field"] == correct[0]["field"]
-        assert parsed_filters[0]["expression"].value == correct[0]["expression"]
-        assert parsed_filters[0]["value"] == correct[0]["value"]
-        assert parsed_filters[1]["field"] == correct[1]["field"]
-        assert parsed_filters[1]["expression"].value == correct[1]["expression"]
-        assert parsed_filters[1]["value"] == correct[1]["value"]
+        correct = [
+            {"field": "orders.order_year", "value": start, "expression": "greater_or_equal_than"},
+            {"field": "orders.order_year", "value": end, "expression": "less_or_equal_than"},
+        ]
+        for parsed_filters in [dashboard_parsed_filters, element_parsed_filters]:
+            assert parsed_filters[0]["field"] == correct[0]["field"]
+            assert parsed_filters[0]["expression"].value == correct[0]["expression"]
+            assert parsed_filters[0]["value"] == correct[0]["value"]
+            assert parsed_filters[1]["field"] == correct[1]["field"]
+            assert parsed_filters[1]["expression"].value == correct[1]["expression"]
+            assert parsed_filters[1]["value"] == correct[1]["value"]
 
 
 @pytest.mark.query
-def test_dashboard_filter_timezone(fresh_project):
-    date_format = "%Y-%m-%dT%H:%M:%S"
-    fresh_project.set_timezone("Pacific/Apia")
-    connection = MetricsLayerConnection(project=fresh_project, connections=[])
-    dash = connection.get_dashboard("sales_dashboard")
+@pytest.mark.parametrize("dt", _generate_dt_params())
+def test_dashboard_filter_timezone(fresh_project, dt):
+    with pendulum.travel_to(dt):
+        date_format = "%Y-%m-%dT%H:%M:%S"
+        fresh_project.set_timezone("Pacific/Apia")
+        connection = MetricsLayerConnection(project=fresh_project, connections=[])
+        dash = connection.get_dashboard("sales_dashboard")
 
-    raw_filter_dict = {"field": "orders.order_date", "value": "week to date"}
-    dash.filters = [raw_filter_dict]
-    dashboard_parsed_filters = dash.parsed_filters()
+        raw_filter_dict = {"field": "orders.order_date", "value": "week to date"}
+        dash.filters = [raw_filter_dict]
+        dashboard_parsed_filters = dash.parsed_filters()
 
-    last_element = dash.elements()[-1]
-    last_element.filters = [raw_filter_dict]
-    element_parsed_filters = last_element.parsed_filters()
+        last_element = dash.elements()[-1]
+        last_element.filters = [raw_filter_dict]
+        element_parsed_filters = last_element.parsed_filters()
 
-    # These are 24 hours apart so this test should always fail if we get the wrong timezone
-    to_sub = 1 if pendulum.now("Pacific/Apia").day_of_week != 0 else 0
-    start = pendulum.now("Pacific/Apia").start_of("week").strftime(date_format)
-    end = pendulum.now("Pacific/Apia").subtract(days=to_sub).end_of("day").strftime(date_format)
-    wrong_end = pendulum.now("Pacific/Niue").subtract(days=to_sub).end_of("day").strftime(date_format)
-    correct = [
-        {"field": "orders.order_date", "value": start, "expression": "greater_or_equal_than"},
-        {"field": "orders.order_date", "value": end, "expression": "less_or_equal_than"},
-    ]
-    for parsed_filters in [dashboard_parsed_filters, element_parsed_filters]:
-        assert parsed_filters[0]["field"] == correct[0]["field"]
-        assert parsed_filters[0]["expression"].value == correct[0]["expression"]
-        assert parsed_filters[0]["value"] == correct[0]["value"]
-        assert parsed_filters[1]["field"] == correct[1]["field"]
-        assert parsed_filters[1]["expression"].value == correct[1]["expression"]
-        assert parsed_filters[1]["value"] == correct[1]["value"]
-        assert parsed_filters[1]["value"] != wrong_end
+        # These are 24 hours apart so this test should always fail if we get the wrong timezone
+        to_sub = 1 if pendulum.now("Pacific/Apia").day_of_week != 0 else 0
+        start = pendulum.now("Pacific/Apia").start_of("week").strftime(date_format)
+        end = pendulum.now("Pacific/Apia").subtract(days=to_sub).end_of("day").strftime(date_format)
+        wrong_end = pendulum.now("Pacific/Niue").subtract(days=to_sub).end_of("day").strftime(date_format)
+        correct = [
+            {"field": "orders.order_date", "value": start, "expression": "greater_or_equal_than"},
+            {"field": "orders.order_date", "value": end, "expression": "less_or_equal_than"},
+        ]
+        for parsed_filters in [dashboard_parsed_filters, element_parsed_filters]:
+            assert parsed_filters[0]["field"] == correct[0]["field"]
+            assert parsed_filters[0]["expression"].value == correct[0]["expression"]
+            assert parsed_filters[0]["value"] == correct[0]["value"]
+            assert parsed_filters[1]["field"] == correct[1]["field"]
+            assert parsed_filters[1]["expression"].value == correct[1]["expression"]
+            assert parsed_filters[1]["value"] == correct[1]["value"]
+            assert parsed_filters[1]["value"] != wrong_end
 
 
 @pytest.mark.query
@@ -187,233 +200,246 @@ def test_dashboard_filter_timezone(fresh_project):
         {"field": "customers.gender", "value": "-Male, Female"},
     ],
 )
-def test_dashboard_filter_processing(connection, raw_filter_dict):
-    dash = connection.get_dashboard("sales_dashboard")
-    dash.filters = [raw_filter_dict]
+@pytest.mark.parametrize("dt", _generate_dt_params())
+def test_dashboard_filter_processing(connection, raw_filter_dict, dt):
+    with pendulum.travel_to(dt):
+        dash = connection.get_dashboard("sales_dashboard")
+        dash.filters = [raw_filter_dict]
 
-    expression_lookup = {
-        "Male": "equal_to",
-        "-Male": "not_equal_to",
-        "-Ma%": "does_not_start_with_case_insensitive",
-        "-%Ma": "does_not_end_with_case_insensitive",
-        "-%ale%": "does_not_contain_case_insensitive",
-        "Fe%": "starts_with_case_insensitive",
-        "%Fe": "ends_with_case_insensitive",
-        "%male%": "contains_case_insensitive",
-        "=100": "equal_to",
-        ">100": "greater_than",
-        "<100": "less_than",
-        "<=120": "less_or_equal_than",
-        ">=120": "greater_or_equal_than",
-        "!=120": "not_equal_to",
-        "<>120": "not_equal_to",
-        "Male, Female": "isin",
-        "-Male, -Female": "isnotin",
-        "-NULL": "is_not_null",
-        "NULL": "is_null",
-        "TRUE": "equal_to",
-        True: "equal_to",
-        False: "equal_to",
-        "after 2021-02-03": "greater_or_equal_than",
-        "2021-02-03 until 2022-02-03": "greater_or_equal_than",
-        "2021-02-03 until yesterday": "greater_or_equal_than",
-        "2021-02-03 until this month": "greater_or_equal_than",
-        "before 2021-02-03": "less_or_equal_than",
-        "on 2021-02-03": "equal_to",
-        "not on 2021-02-03": "not_equal_to",
-        "today": "greater_or_equal_than",
-        "yesterday": "greater_or_equal_than",
-        "this week": "greater_or_equal_than",
-        "this month": "greater_or_equal_than",
-        "this quarter": "greater_or_equal_than",
-        "this year": "greater_or_equal_than",
-        "last week": "greater_or_equal_than",
-        "last month": "greater_or_equal_than",
-        "last quarter": "greater_or_equal_than",
-        "last year": "greater_or_equal_than",
-        "week to date": "greater_or_equal_than",
-        "month to date": "greater_or_equal_than",
-        "quarter to date": "greater_or_equal_than",
-        "year to date": "greater_or_equal_than",
-        "last week to date": "greater_or_equal_than",
-        "52 weeks ago to date": "greater_or_equal_than",
-        "12 months ago to date": "greater_or_equal_than",
-        "1 year ago to date": "greater_or_equal_than",
-        "1 year ago for 3 months": "greater_or_equal_than",
-        "1 year ago for 30 days": "greater_or_equal_than",
-        "2 years ago": "greater_or_equal_than",
-        "3 months": "greater_or_equal_than",
-        "1 week": "greater_or_equal_than",
-        "2 days": "greater_or_equal_than",
-        "1 quarter": "greater_or_equal_than",
-    }
-    date_format = "%Y-%m-%dT%H:%M:%S"
-    value_lookup = {
-        "Male": "Male",
-        "-Male": "Male",
-        "-Ma%": "Ma",
-        "-%Ma": "Ma",
-        "-%ale%": "ale",
-        "Fe%": "Fe",
-        "%Fe": "Fe",
-        "%male%": "male",
-        "=100": 100,
-        ">100": 100,
-        "<100": 100,
-        "<=120": 120,
-        ">=120": 120,
-        "!=120": 120,
-        "<>120": 120,
-        "Male, Female": ["Male", "Female"],
-        "-Male, -Female": ["Male", "Female"],
-        "-NULL": None,
-        "NULL": None,
-        "TRUE": True,
-        True: True,
-        False: False,
-        "after 2021-02-03": "2021-02-03T00:00:00",
-        "2021-02-03 until 2022-02-03": "2021-02-03T00:00:00",
-        "2021-02-03 until yesterday": "2021-02-03T00:00:00",
-        "2021-02-03 until this month": "2021-02-03T00:00:00",
-        "before 2021-02-03": "2021-02-03T00:00:00",
-        "on 2021-02-03": "2021-02-03T00:00:00",
-        "not on 2021-02-03": "2021-02-03T00:00:00",
-        "today": pendulum.now("UTC").start_of("day").strftime(date_format),
-        "yesterday": pendulum.now("UTC").subtract(days=1).start_of("day").strftime(date_format),
-        "this week": pendulum.now("UTC").subtract(weeks=0).start_of("week").strftime(date_format),
-        "this month": pendulum.now("UTC").subtract(months=0).start_of("month").strftime(date_format),
-        "this quarter": pendulum.now("UTC").subtract(months=0).first_of("quarter").strftime(date_format),
-        "this year": pendulum.now("UTC").subtract(years=0).start_of("year").strftime(date_format),
-        "last week": pendulum.now("UTC").subtract(weeks=1).start_of("week").strftime(date_format),
-        "last month": pendulum.now("UTC").subtract(months=1).start_of("month").strftime(date_format),
-        "last quarter": pendulum.now("UTC").subtract(months=3).first_of("quarter").strftime(date_format),
-        "last year": pendulum.now("UTC").subtract(years=1).start_of("year").strftime(date_format),
-        "week to date": pendulum.now("UTC").subtract(weeks=0).start_of("week").strftime(date_format),
-        "month to date": pendulum.now("UTC").subtract(months=0).start_of("month").strftime(date_format),
-        "quarter to date": pendulum.now("UTC").subtract(months=0).first_of("quarter").strftime(date_format),
-        "year to date": pendulum.now("UTC").subtract(years=0).start_of("year").strftime(date_format),
-        "last week to date": pendulum.now("UTC").subtract(weeks=1).start_of("week").strftime(date_format),
-        "52 weeks ago to date": pendulum.now("UTC").subtract(weeks=52).start_of("week").strftime(date_format),
-        "12 months ago to date": pendulum.now("UTC")
-        .subtract(months=12)
-        .start_of("month")
-        .strftime(date_format),
-        "1 year ago to date": pendulum.now("UTC").subtract(years=1).start_of("year").strftime(date_format),
-        "1 year ago for 3 months": pendulum.now("UTC")
-        .subtract(years=1)
-        .start_of("year")
-        .strftime(date_format),
-        "1 year ago for 30 days": pendulum.now("UTC")
-        .subtract(years=1)
-        .start_of("year")
-        .strftime(date_format),
-        "2 years ago": pendulum.now("UTC").subtract(years=2).start_of("year").strftime(date_format),
-        "3 months": pendulum.now("UTC").subtract(months=2).start_of("month").strftime(date_format),
-        "1 week": pendulum.now("UTC").start_of("week").strftime(date_format),
-        "2 days": pendulum.now("UTC").subtract(days=1).start_of("day").strftime(date_format),
-        "1 quarter": pendulum.now("UTC").first_of("quarter").strftime(date_format),
-    }
+        expression_lookup = {
+            "Male": "equal_to",
+            "-Male": "not_equal_to",
+            "-Ma%": "does_not_start_with_case_insensitive",
+            "-%Ma": "does_not_end_with_case_insensitive",
+            "-%ale%": "does_not_contain_case_insensitive",
+            "Fe%": "starts_with_case_insensitive",
+            "%Fe": "ends_with_case_insensitive",
+            "%male%": "contains_case_insensitive",
+            "=100": "equal_to",
+            ">100": "greater_than",
+            "<100": "less_than",
+            "<=120": "less_or_equal_than",
+            ">=120": "greater_or_equal_than",
+            "!=120": "not_equal_to",
+            "<>120": "not_equal_to",
+            "Male, Female": "isin",
+            "-Male, -Female": "isnotin",
+            "-NULL": "is_not_null",
+            "NULL": "is_null",
+            "TRUE": "equal_to",
+            True: "equal_to",
+            False: "equal_to",
+            "after 2021-02-03": "greater_or_equal_than",
+            "2021-02-03 until 2022-02-03": "greater_or_equal_than",
+            "2021-02-03 until yesterday": "greater_or_equal_than",
+            "2021-02-03 until this month": "greater_or_equal_than",
+            "before 2021-02-03": "less_or_equal_than",
+            "on 2021-02-03": "equal_to",
+            "not on 2021-02-03": "not_equal_to",
+            "today": "greater_or_equal_than",
+            "yesterday": "greater_or_equal_than",
+            "this week": "greater_or_equal_than",
+            "this month": "greater_or_equal_than",
+            "this quarter": "greater_or_equal_than",
+            "this year": "greater_or_equal_than",
+            "last week": "greater_or_equal_than",
+            "last month": "greater_or_equal_than",
+            "last quarter": "greater_or_equal_than",
+            "last year": "greater_or_equal_than",
+            "week to date": "greater_or_equal_than",
+            "month to date": "greater_or_equal_than",
+            "quarter to date": "greater_or_equal_than",
+            "year to date": "greater_or_equal_than",
+            "last week to date": "greater_or_equal_than",
+            "52 weeks ago to date": "greater_or_equal_than",
+            "12 months ago to date": "greater_or_equal_than",
+            "1 year ago to date": "greater_or_equal_than",
+            "1 year ago for 3 months": "greater_or_equal_than",
+            "1 year ago for 30 days": "greater_or_equal_than",
+            "2 years ago": "greater_or_equal_than",
+            "3 months": "greater_or_equal_than",
+            "1 week": "greater_or_equal_than",
+            "2 days": "greater_or_equal_than",
+            "1 quarter": "greater_or_equal_than",
+        }
+        date_format = "%Y-%m-%dT%H:%M:%S"
+        value_lookup = {
+            "Male": "Male",
+            "-Male": "Male",
+            "-Ma%": "Ma",
+            "-%Ma": "Ma",
+            "-%ale%": "ale",
+            "Fe%": "Fe",
+            "%Fe": "Fe",
+            "%male%": "male",
+            "=100": 100,
+            ">100": 100,
+            "<100": 100,
+            "<=120": 120,
+            ">=120": 120,
+            "!=120": 120,
+            "<>120": 120,
+            "Male, Female": ["Male", "Female"],
+            "-Male, -Female": ["Male", "Female"],
+            "-NULL": None,
+            "NULL": None,
+            "TRUE": True,
+            True: True,
+            False: False,
+            "after 2021-02-03": "2021-02-03T00:00:00",
+            "2021-02-03 until 2022-02-03": "2021-02-03T00:00:00",
+            "2021-02-03 until yesterday": "2021-02-03T00:00:00",
+            "2021-02-03 until this month": "2021-02-03T00:00:00",
+            "before 2021-02-03": "2021-02-03T00:00:00",
+            "on 2021-02-03": "2021-02-03T00:00:00",
+            "not on 2021-02-03": "2021-02-03T00:00:00",
+            "today": pendulum.now("UTC").start_of("day").strftime(date_format),
+            "yesterday": pendulum.now("UTC").subtract(days=1).start_of("day").strftime(date_format),
+            "this week": pendulum.now("UTC").subtract(weeks=0).start_of("week").strftime(date_format),
+            "this month": pendulum.now("UTC").subtract(months=0).start_of("month").strftime(date_format),
+            "this quarter": pendulum.now("UTC").subtract(months=0).first_of("quarter").strftime(date_format),
+            "this year": pendulum.now("UTC").subtract(years=0).start_of("year").strftime(date_format),
+            "last week": pendulum.now("UTC").subtract(weeks=1).start_of("week").strftime(date_format),
+            "last month": pendulum.now("UTC").subtract(months=1).start_of("month").strftime(date_format),
+            "last quarter": pendulum.now("UTC").subtract(months=3).first_of("quarter").strftime(date_format),
+            "last year": pendulum.now("UTC").subtract(years=1).start_of("year").strftime(date_format),
+            "week to date": pendulum.now("UTC").subtract(weeks=0).start_of("week").strftime(date_format),
+            "month to date": pendulum.now("UTC").subtract(months=0).start_of("month").strftime(date_format),
+            "quarter to date": pendulum.now("UTC")
+            .subtract(months=0)
+            .first_of("quarter")
+            .strftime(date_format),
+            "year to date": pendulum.now("UTC").subtract(years=0).start_of("year").strftime(date_format),
+            "last week to date": pendulum.now("UTC").subtract(weeks=1).start_of("week").strftime(date_format),
+            "52 weeks ago to date": pendulum.now("UTC")
+            .subtract(weeks=52)
+            .start_of("week")
+            .strftime(date_format),
+            "12 months ago to date": pendulum.now("UTC")
+            .subtract(months=12)
+            .start_of("month")
+            .strftime(date_format),
+            "1 year ago to date": pendulum.now("UTC")
+            .subtract(years=1)
+            .start_of("year")
+            .strftime(date_format),
+            "1 year ago for 3 months": pendulum.now("UTC")
+            .subtract(years=1)
+            .start_of("year")
+            .strftime(date_format),
+            "1 year ago for 30 days": pendulum.now("UTC")
+            .subtract(years=1)
+            .start_of("year")
+            .strftime(date_format),
+            "2 years ago": pendulum.now("UTC").subtract(years=2).start_of("year").strftime(date_format),
+            "3 months": pendulum.now("UTC").subtract(months=2).start_of("month").strftime(date_format),
+            "1 week": pendulum.now("UTC").start_of("week").strftime(date_format),
+            "2 days": pendulum.now("UTC").subtract(days=1).start_of("day").strftime(date_format),
+            "1 quarter": pendulum.now("UTC").first_of("quarter").strftime(date_format),
+        }
 
-    second_value_lookup = {
-        "today": pendulum.now("UTC").end_of("day").strftime(date_format),
-        "yesterday": pendulum.now("UTC").subtract(days=1).end_of("day").strftime(date_format),
-        "this week": pendulum.now("UTC").end_of("week").strftime(date_format),
-        "this month": pendulum.now("UTC").end_of("month").strftime(date_format),
-        "this quarter": pendulum.now("UTC").last_of("quarter").strftime(date_format),
-        "this year": pendulum.now("UTC").end_of("year").strftime(date_format),
-        "last week": pendulum.now("UTC").subtract(weeks=1).end_of("week").strftime(date_format),
-        "last month": pendulum.now("UTC").subtract(months=1).end_of("month").strftime(date_format),
-        "last quarter": pendulum.now("UTC").subtract(months=3).last_of("quarter").strftime(date_format),
-        "last year": pendulum.now("UTC").subtract(years=1).end_of("year").strftime(date_format),
-        "2021-02-03 until 2022-02-03": "2022-02-03T00:00:00",
-        "2021-02-03 until yesterday": pendulum.now("UTC")
-        .subtract(days=1)
-        .end_of("day")
-        .strftime(date_format),
-        "2021-02-03 until this month": pendulum.now("UTC").end_of("month").strftime(date_format),
-        "week to date": pendulum.now("UTC")
-        .subtract(days=1 if pendulum.now("UTC").day_of_week != 0 else 0)
-        .end_of("day")
-        .strftime(date_format),
-        "month to date": pendulum.now("UTC")
-        .subtract(days=1 if pendulum.now("UTC").day != 1 else 0)
-        .end_of("day")
-        .strftime(date_format),
-        "quarter to date": pendulum.now("UTC")
-        .subtract(
-            days=1 if pendulum.now("UTC").day != 1 or pendulum.now("UTC").month not in {1, 4, 7, 10} else 0
-        )
-        .end_of("day")
-        .strftime(date_format),
-        "year to date": pendulum.now("UTC").subtract(days=1).end_of("day").strftime(date_format),
-        "last week to date": pendulum.now("UTC")
-        .subtract(weeks=1)
-        .start_of("week")
-        .add(
-            days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("week")).days - 1
-            if pendulum.now("UTC").day_of_week != 0
-            else 0
-        )
-        .end_of("day")
-        .strftime(date_format),
-        "52 weeks ago to date": pendulum.now("UTC")
-        .subtract(weeks=52)
-        .start_of("week")
-        .add(
-            days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("week")).days - 1
-            if pendulum.now("UTC").day_of_week != 0
-            else 0
-        )
-        .end_of("day")
-        .strftime(date_format),
-        "12 months ago to date": pendulum.now("UTC")
-        .subtract(months=12)
-        .start_of("month")
-        .add(
-            days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("month")).days - 1
-            if pendulum.now("UTC").day != 0
-            else 0
-        )
-        .end_of("day")
-        .strftime(date_format),
-        "1 year ago to date": pendulum.now("UTC")
-        .subtract(years=1)
-        .start_of("year")
-        .add(days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("year")).days - 1)
-        .end_of("day")
-        .strftime(date_format),
-        "1 year ago for 3 months": pendulum.now("UTC")
-        .subtract(years=1)
-        .start_of("year")
-        .add(months=2)
-        .end_of("month")
-        .strftime(date_format),
-        "1 year ago for 30 days": pendulum.now("UTC")
-        .subtract(years=1)
-        .start_of("year")
-        .add(days=29)
-        .end_of("day")
-        .strftime(date_format),
-        "2 years ago": pendulum.now("UTC").subtract(years=2).end_of("year").strftime(date_format),
-        "3 months": pendulum.now("UTC").end_of("month").strftime(date_format),
-        "1 week": pendulum.now("UTC").end_of("week").strftime(date_format),
-        "2 days": pendulum.now("UTC").end_of("day").strftime(date_format),
-        "1 quarter": pendulum.now("UTC").last_of("quarter").strftime(date_format),
-    }
-    if raw_filter_dict["value"] == "-Male, Female":
-        with pytest.raises(QueryError) as exc_info:
-            dash.parsed_filters()
-        assert exc_info.value
-    else:
-        parsed_filters = dash.parsed_filters()
-        assert len(parsed_filters) in {1, 2}
-        assert parsed_filters[0]["field"] == raw_filter_dict["field"]
-        assert parsed_filters[0]["expression"].value == expression_lookup[raw_filter_dict["value"]]
-        assert parsed_filters[0]["value"] == value_lookup[raw_filter_dict["value"]]
-        if raw_filter_dict["value"] in second_value_lookup or len(parsed_filters) == 2:
-            assert parsed_filters[1]["field"] == raw_filter_dict["field"]
-            assert parsed_filters[1]["expression"].value == "less_or_equal_than"
-            assert parsed_filters[1]["value"] == second_value_lookup[raw_filter_dict["value"]]
+        second_value_lookup = {
+            "today": pendulum.now("UTC").end_of("day").strftime(date_format),
+            "yesterday": pendulum.now("UTC").subtract(days=1).end_of("day").strftime(date_format),
+            "this week": pendulum.now("UTC").end_of("week").strftime(date_format),
+            "this month": pendulum.now("UTC").end_of("month").strftime(date_format),
+            "this quarter": pendulum.now("UTC").last_of("quarter").strftime(date_format),
+            "this year": pendulum.now("UTC").end_of("year").strftime(date_format),
+            "last week": pendulum.now("UTC").subtract(weeks=1).end_of("week").strftime(date_format),
+            "last month": pendulum.now("UTC").subtract(months=1).end_of("month").strftime(date_format),
+            "last quarter": pendulum.now("UTC").subtract(months=3).last_of("quarter").strftime(date_format),
+            "last year": pendulum.now("UTC").subtract(years=1).end_of("year").strftime(date_format),
+            "2021-02-03 until 2022-02-03": "2022-02-03T00:00:00",
+            "2021-02-03 until yesterday": pendulum.now("UTC")
+            .subtract(days=1)
+            .end_of("day")
+            .strftime(date_format),
+            "2021-02-03 until this month": pendulum.now("UTC").end_of("month").strftime(date_format),
+            "week to date": pendulum.now("UTC")
+            .subtract(days=1 if pendulum.now("UTC").day_of_week != 0 else 0)
+            .end_of("day")
+            .strftime(date_format),
+            "month to date": pendulum.now("UTC")
+            .subtract(days=1 if pendulum.now("UTC").day != 1 else 0)
+            .end_of("day")
+            .strftime(date_format),
+            "quarter to date": pendulum.now("UTC")
+            .subtract(
+                days=1
+                if pendulum.now("UTC").day != 1 or pendulum.now("UTC").month not in {1, 4, 7, 10}
+                else 0
+            )
+            .end_of("day")
+            .strftime(date_format),
+            "year to date": pendulum.now("UTC").subtract(days=1).end_of("day").strftime(date_format),
+            "last week to date": pendulum.now("UTC")
+            .subtract(weeks=1)
+            .start_of("week")
+            .add(
+                days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("week")).days - 1
+                if pendulum.now("UTC").day_of_week != 0
+                else 0
+            )
+            .end_of("day")
+            .strftime(date_format),
+            "52 weeks ago to date": pendulum.now("UTC")
+            .subtract(weeks=52)
+            .start_of("week")
+            .add(
+                days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("week")).days - 1
+                if pendulum.now("UTC").day_of_week != 0
+                else 0
+            )
+            .end_of("day")
+            .strftime(date_format),
+            "12 months ago to date": pendulum.now("UTC")
+            .subtract(months=12)
+            .start_of("month")
+            .add(
+                days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("month")).days - 1
+                if pendulum.now("UTC").day != 0
+                else 0
+            )
+            .end_of("day")
+            .strftime(date_format),
+            "1 year ago to date": pendulum.now("UTC")
+            .subtract(years=1)
+            .start_of("year")
+            .add(days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("year")).days - 1)
+            .end_of("day")
+            .strftime(date_format),
+            "1 year ago for 3 months": pendulum.now("UTC")
+            .subtract(years=1)
+            .start_of("year")
+            .add(months=2)
+            .end_of("month")
+            .strftime(date_format),
+            "1 year ago for 30 days": pendulum.now("UTC")
+            .subtract(years=1)
+            .start_of("year")
+            .add(days=29)
+            .end_of("day")
+            .strftime(date_format),
+            "2 years ago": pendulum.now("UTC").subtract(years=2).end_of("year").strftime(date_format),
+            "3 months": pendulum.now("UTC").end_of("month").strftime(date_format),
+            "1 week": pendulum.now("UTC").end_of("week").strftime(date_format),
+            "2 days": pendulum.now("UTC").end_of("day").strftime(date_format),
+            "1 quarter": pendulum.now("UTC").last_of("quarter").strftime(date_format),
+        }
+        if raw_filter_dict["value"] == "-Male, Female":
+            with pytest.raises(QueryError) as exc_info:
+                dash.parsed_filters()
+            assert exc_info.value
+        else:
+            parsed_filters = dash.parsed_filters()
+            assert len(parsed_filters) in {1, 2}
+            assert parsed_filters[0]["field"] == raw_filter_dict["field"]
+            assert parsed_filters[0]["expression"].value == expression_lookup[raw_filter_dict["value"]]
+            assert parsed_filters[0]["value"] == value_lookup[raw_filter_dict["value"]]
+            if raw_filter_dict["value"] in second_value_lookup or len(parsed_filters) == 2:
+                assert parsed_filters[1]["field"] == raw_filter_dict["field"]
+                assert parsed_filters[1]["expression"].value == "less_or_equal_than"
+                assert parsed_filters[1]["value"] == second_value_lookup[raw_filter_dict["value"]]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -397,7 +397,7 @@ def test_dashboard_filter_processing(connection, raw_filter_dict, dt):
             .start_of("month")
             .add(
                 days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("month")).days - 1
-                if pendulum.now("UTC").day != 0
+                if pendulum.now("UTC").day != 1
                 else 0
             )
             .end_of("day")

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -371,7 +371,12 @@ def test_dashboard_filter_processing(connection, raw_filter_dict, dt):
             )
             .end_of("day")
             .strftime(date_format),
-            "year to date": pendulum.now("UTC").subtract(days=1).end_of("day").strftime(date_format),
+            "year to date": pendulum.now("UTC")
+            .subtract(
+                days=1 if pendulum.now("UTC").date() != pendulum.now("UTC").start_of("year").date() else 0
+            )
+            .end_of("day")
+            .strftime(date_format),
             "last week to date": pendulum.now("UTC")
             .subtract(weeks=1)
             .start_of("week")
@@ -405,7 +410,11 @@ def test_dashboard_filter_processing(connection, raw_filter_dict, dt):
             "1 year ago to date": pendulum.now("UTC")
             .subtract(years=1)
             .start_of("year")
-            .add(days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("year")).days - 1)
+            .add(
+                days=(pendulum.now("UTC") - pendulum.now("UTC").start_of("year")).days - 1
+                if pendulum.now("UTC").date() != pendulum.now("UTC").start_of("year").date()
+                else 0
+            )
             .end_of("day")
             .strftime(date_format),
             "1 year ago for 3 months": pendulum.now("UTC")


### PR DESCRIPTION
This PR tests every day of the year! Right now, only the current datetime is tested, which is not the best practice; edge cases might be caught on some days but not others.

Testing every day takes some time, so we give all of these the `extra_dt` marker. Tests with this marker do not run by default, but they do in CI/CD. The original tests are given the `primary_dt` marker.

These new tests caught some issues in the test suite, which this PR also fixes.