### PR TITLE
Handle all falsy `filters`

### DIFF
--- a/metrics_layer/core/model/field.py
+++ b/metrics_layer/core/model/field.py
@@ -279,7 +279,7 @@ class Field(MetricsLayerBase, SQLReplacement):
                 )
             # You cannot apply a filter to a field that is the same name
             # as the field itself (this doesn't make sense)
-            filters_to_apply = [f for f in definition.get("filters", []) if f.get("field") != self.name]
+            filters_to_apply = [f for f in self.filters if f.get("field") != self.name]
 
             else_0 = False
             if non_additive_dimension := self.non_additive_dimension:


### PR DESCRIPTION
We have a bug that's commonly found with `dict.get()`: If `definition["filters"]` is `None` (which is allowed), then we'll return that instead of hitting the desired default of `[]`. The `self.filters` property has logic to handle this, so let's use that instead.

We probably didn't catch this before, since the condition to enter this block has changed to `self.filters or self.non_additive_dimension`, which allows for falsy filters.